### PR TITLE
Add Flask Salesforce integration app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+venv/
+ENV/
+.env.local
+data/orgs.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# Sfintegrator
+# SF Integrator
+
+A lightweight Flask application to manage Salesforce org connections via OAuth 2.0 and run SOQL queries.
+
+## Features
+
+- Configure multiple Salesforce orgs (production, sandbox, or custom domains).
+- Perform OAuth 2.0 flows to connect orgs and store tokens securely on disk.
+- Run SOQL queries against connected orgs directly from the UI.
+- Built-in guide documenting Salesforce and application configuration steps.
+
+## Getting started
+
+1. Create and activate a Python 3.10+ virtual environment.
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Set the Flask app and run the development server:
+
+   ```bash
+   export FLASK_APP=app
+   flask run
+   ```
+
+   The app runs on <http://localhost:5000>.
+
+4. Configure your Salesforce connected app with the callback URL `http://localhost:5000/oauth/callback` (or your deployed URL).
+5. Use the Org Configuration page to add your org credentials and authorize via OAuth.
+
+## Environment variables
+
+Set `FLASK_SECRET_KEY` to override the default secret key in production deployments.
+
+## Data storage
+
+Org definitions and OAuth tokens are stored in `data/orgs.json`. Treat this file as sensitive because it may contain refresh tokens.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,5 @@
+from app import app
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+
+from flask import Flask
+
+from .routes import main_bp
+from .storage import ensure_storage
+
+
+def create_app() -> Flask:
+    """Application factory."""
+    ensure_storage()
+    app = Flask(__name__)
+    app.config.from_mapping(SECRET_KEY=os.environ.get("FLASK_SECRET_KEY", "dev"))
+    app.register_blueprint(main_bp)
+    return app
+
+
+app = create_app()

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import secrets
+
+from flask import (Blueprint, Response, jsonify, redirect, render_template,
+                   request, session, url_for)
+
+from .salesforce import (SalesforceError, build_authorize_url,
+                         exchange_code_for_token, query, serialize_org)
+from .storage import OrgConfig, storage
+
+main_bp = Blueprint("main", __name__)
+
+
+@main_bp.route("/")
+def index() -> str:
+    orgs = [serialize_org(org) for org in storage.list()]
+    return render_template("index.html", orgs=orgs)
+
+
+@main_bp.route("/orgs")
+def manage_orgs() -> str:
+    orgs = storage.list()
+    return render_template("orgs.html", orgs=orgs)
+
+
+@main_bp.route("/guide")
+def guide() -> str:
+    return render_template("guide.html")
+
+
+@main_bp.route("/api/orgs", methods=["GET"])
+def api_list_orgs() -> Response:
+    orgs = [serialize_org(org) for org in storage.list()]
+    return jsonify(orgs)
+
+
+@main_bp.route("/api/orgs", methods=["POST"])
+def api_create_org() -> Response:
+    data = request.get_json(force=True)
+    required = {"id", "label", "client_id", "environment", "redirect_uri"}
+    missing = required - data.keys()
+    if missing:
+        return jsonify({"error": f"Missing required fields: {', '.join(sorted(missing))}"}), 400
+
+    existing = storage.get(data["id"])
+    client_secret = data.get("client_secret") or (existing.client_secret if existing else None)
+    if not client_secret:
+        return jsonify({"error": "client_secret is required for new orgs"}), 400
+
+    payload = {key: data.get(key) for key in OrgConfig.__dataclass_fields__.keys()}
+    payload["client_secret"] = client_secret.strip()
+    if payload.get("auth_scope"):
+        payload["auth_scope"] = payload["auth_scope"].strip() or "full refresh_token"
+    else:
+        payload["auth_scope"] = "full refresh_token"
+    if payload.get("client_id"):
+        payload["client_id"] = payload["client_id"].strip()
+    if payload.get("label"):
+        payload["label"] = payload["label"].strip()
+    if payload.get("environment"):
+        payload["environment"] = payload["environment"].strip()
+    if payload.get("redirect_uri"):
+        payload["redirect_uri"] = payload["redirect_uri"].strip()
+    if not payload.get("environment"):
+        return jsonify({"error": "environment is required"}), 400
+    if not payload.get("redirect_uri"):
+        return jsonify({"error": "redirect_uri is required"}), 400
+    if existing:
+        payload["access_token"] = existing.access_token if data.get("access_token") is None else data.get("access_token")
+        payload["refresh_token"] = existing.refresh_token if data.get("refresh_token") is None else data.get("refresh_token")
+        payload["instance_url"] = existing.instance_url if data.get("instance_url") is None else data.get("instance_url")
+
+    org = OrgConfig(**payload)
+    storage.upsert(org)
+    return jsonify(serialize_org(org)), 201 if not existing else 200
+
+
+@main_bp.route("/api/orgs/<org_id>", methods=["DELETE"])
+def api_delete_org(org_id: str) -> Response:
+    storage.delete(org_id)
+    return Response(status=204)
+
+
+@main_bp.route("/auth/<org_id>")
+def start_auth(org_id: str):
+    org = storage.get(org_id)
+    if not org:
+        return jsonify({"error": "Unknown org"}), 404
+    state = secrets.token_urlsafe(24)
+    session["oauth_state"] = state
+    session["oauth_org_id"] = org_id
+    return redirect(build_authorize_url(org, state))
+
+
+@main_bp.route("/oauth/callback")
+def oauth_callback():
+    state = request.args.get("state")
+    code = request.args.get("code")
+    if not state or not code:
+        return jsonify({"error": "Missing state or code"}), 400
+
+    expected_state = session.get("oauth_state")
+    org_id = session.get("oauth_org_id")
+    if not expected_state or state != expected_state or not org_id:
+        return jsonify({"error": "Invalid session state"}), 400
+
+    org = storage.get(org_id)
+    if not org:
+        return jsonify({"error": "Unknown org"}), 404
+
+    updated = exchange_code_for_token(org, code)
+    return redirect(url_for("main.index", message=f"Connected {updated.label}"))
+
+
+@main_bp.route("/api/query", methods=["POST"])
+def api_query() -> Response:
+    payload = request.get_json(force=True)
+    org_id = payload.get("org_id")
+    soql = payload.get("query")
+    if not org_id or not soql:
+        return jsonify({"error": "org_id and query are required"}), 400
+
+    org = storage.get(org_id)
+    if not org:
+        return jsonify({"error": "Unknown org"}), 404
+
+    try:
+        result = query(org, soql)
+    except SalesforceError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    return jsonify(result)
+
+
+@main_bp.errorhandler(SalesforceError)
+def handle_salesforce_error(exc: SalesforceError):
+    return jsonify({"error": str(exc)}), 400

--- a/app/salesforce.py
+++ b/app/salesforce.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import Dict, Optional
+
+import requests
+
+from .storage import OrgConfig, storage
+
+logger = logging.getLogger(__name__)
+
+
+class SalesforceError(RuntimeError):
+    pass
+
+
+def build_authorize_url(org: OrgConfig, state: str) -> str:
+    params = {
+        "response_type": "code",
+        "client_id": org.client_id,
+        "redirect_uri": org.redirect_uri,
+        "scope": org.auth_scope,
+        "state": state,
+    }
+    query = "&".join(f"{key}={requests.utils.quote(value)}" for key, value in params.items())
+    return f"{org.login_url}/services/oauth2/authorize?{query}"
+
+
+def exchange_code_for_token(org: OrgConfig, code: str) -> OrgConfig:
+    payload = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "client_id": org.client_id,
+        "client_secret": org.client_secret,
+        "redirect_uri": org.redirect_uri,
+    }
+    response = requests.post(f"{org.login_url}/services/oauth2/token", data=payload, timeout=30)
+    if not response.ok:
+        raise SalesforceError(f"Failed to exchange code: {response.text}")
+    data = response.json()
+    updated = OrgConfig(**{**asdict(org), **{k: data.get(k) for k in ("access_token", "refresh_token", "instance_url")}})
+    storage.upsert(updated)
+    return updated
+
+
+def refresh_access_token(org: OrgConfig) -> OrgConfig:
+    if not org.refresh_token:
+        raise SalesforceError("Missing refresh token; please re-authorize the org")
+    payload = {
+        "grant_type": "refresh_token",
+        "refresh_token": org.refresh_token,
+        "client_id": org.client_id,
+        "client_secret": org.client_secret,
+    }
+    response = requests.post(f"{org.login_url}/services/oauth2/token", data=payload, timeout=30)
+    if not response.ok:
+        raise SalesforceError(f"Failed to refresh token: {response.text}")
+    data = response.json()
+    updated = OrgConfig(**{**asdict(org), **{k: data.get(k) for k in ("access_token", "instance_url")}})
+    storage.upsert(updated)
+    return updated
+
+
+def query(org: OrgConfig, soql: str) -> Dict:
+    if not org.access_token or not org.instance_url:
+        raise SalesforceError("Org is not authorized. Please connect using OAuth first.")
+
+    headers = {"Authorization": f"Bearer {org.access_token}"}
+    params = {"q": soql}
+    url = f"{org.instance_url}/services/data/v57.0/query"
+    response = requests.get(url, headers=headers, params=params, timeout=30)
+
+    if response.status_code == 401 and org.refresh_token:
+        refreshed = refresh_access_token(org)
+        headers = {"Authorization": f"Bearer {refreshed.access_token}"}
+        response = requests.get(url, headers=headers, params=params, timeout=30)
+
+    if not response.ok:
+        raise SalesforceError(f"Salesforce query failed: {response.text}")
+
+    return response.json()
+
+
+def serialize_org(org: OrgConfig) -> Dict[str, Optional[str]]:
+    data = asdict(org)
+    # Hide secrets when exposing to the browser
+    data["client_secret"] = "***"
+    if data.get("access_token"):
+        data["access_token"] = "set"
+    if data.get("refresh_token"):
+        data["refresh_token"] = "set"
+    return data

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,229 @@
+const state = {
+  selectedOrg: null,
+};
+
+function showToast(message, type = "success") {
+  const container = document.createElement("div");
+  container.className = `toast align-items-center text-bg-${type} border-0 position-fixed bottom-0 end-0 m-3`;
+  container.setAttribute("role", "alert");
+  container.setAttribute("aria-live", "assertive");
+  container.setAttribute("aria-atomic", "true");
+  container.innerHTML = `
+    <div class="d-flex">
+      <div class="toast-body">${message}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  `;
+  document.body.appendChild(container);
+  const toast = new bootstrap.Toast(container);
+  toast.show();
+  container.addEventListener("hidden.bs.toast", () => container.remove());
+}
+
+function bindOrgSelection() {
+  document.querySelectorAll(".org-select").forEach((button) => {
+    button.addEventListener("click", () => {
+      state.selectedOrg = button.dataset.org;
+      const label = button.querySelector("strong")?.textContent.trim() ?? button.textContent.trim();
+      document.getElementById("selected-org").value = label;
+      document.querySelectorAll(".org-select").forEach((btn) => btn.classList.remove("active"));
+      button.classList.add("active");
+    });
+  });
+}
+
+function renderQueryResult(data) {
+  const container = document.getElementById("query-result");
+  if (!data || !data.records || data.records.length === 0) {
+    container.innerHTML = '<p class="text-muted">No records returned.</p>';
+    return;
+  }
+  const records = data.records;
+  const columns = Object.keys(records[0]);
+  const headerRow = columns.map((col) => `<th>${col}</th>`).join("");
+  const rows = records
+    .map((record) => `<tr>${columns.map((col) => `<td>${escapeHtml(record[col])}</td>`).join("")}</tr>`)
+    .join("");
+
+  container.innerHTML = `
+    <table class="table table-striped">
+      <thead><tr>${headerRow}</tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+}
+
+function escapeHtml(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function bindQueryForm() {
+  const form = document.getElementById("query-form");
+  if (!form) return;
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const query = document.getElementById("soql-query").value.trim();
+    if (!state.selectedOrg) {
+      showToast("Select an org before running a query", "warning");
+      return;
+    }
+    if (!query) {
+      showToast("Enter a SOQL query", "warning");
+      return;
+    }
+    try {
+      const response = await fetch("/api/query", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ org_id: state.selectedOrg, query }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Query failed");
+      }
+      renderQueryResult(data);
+    } catch (error) {
+      showToast(error.message, "danger");
+    }
+  });
+}
+
+function updateCustomEnvironmentVisibility(selectElement) {
+  const input = document.getElementById("org-custom-environment");
+  if (!input) return;
+  if (selectElement.value === "custom") {
+    input.classList.remove("d-none");
+    input.required = true;
+  } else {
+    input.classList.add("d-none");
+    input.required = false;
+    input.value = "";
+  }
+}
+
+function resetOrgForm(form) {
+  form.reset();
+  form.dataset.mode = "create";
+  form.dataset.orgId = "";
+  document.getElementById("org-form-submit").textContent = "Save org";
+  const environmentSelect = document.getElementById("org-environment");
+  environmentSelect.value = "production";
+  document.getElementById("org-custom-environment").value = "";
+  updateCustomEnvironmentVisibility(environmentSelect);
+}
+
+function bindOrgForm() {
+  const form = document.getElementById("org-form");
+  if (!form) return;
+  form.dataset.mode = "create";
+  const environmentSelect = document.getElementById("org-environment");
+  const customEnvironmentInput = document.getElementById("org-custom-environment");
+  environmentSelect.addEventListener("change", () => updateCustomEnvironmentVisibility(environmentSelect));
+  document.getElementById("org-form-reset").addEventListener("click", () => resetOrgForm(form));
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    let environment = environmentSelect.value.trim();
+    if (environment === "custom") {
+      environment = customEnvironmentInput.value.trim();
+    }
+    const payload = {
+      id: document.getElementById("org-id").value.trim(),
+      label: document.getElementById("org-label").value.trim(),
+      environment,
+      client_id: document.getElementById("org-client-id").value.trim(),
+      client_secret: document.getElementById("org-client-secret").value.trim(),
+      redirect_uri: document.getElementById("org-redirect-uri").value.trim(),
+      auth_scope: document.getElementById("org-scope").value.trim() || "full refresh_token",
+    };
+
+    if (!payload.id || !payload.label || !payload.client_id || !payload.redirect_uri || !payload.environment) {
+      showToast("Please fill all required fields", "warning");
+      return;
+    }
+
+    if (form.dataset.mode === "create" && !payload.client_secret) {
+      showToast("Enter the consumer secret for new orgs", "warning");
+      return;
+    }
+
+    if (!payload.client_secret && form.dataset.mode !== "create") {
+      delete payload.client_secret;
+    }
+
+    try {
+      const response = await fetch("/api/orgs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Unable to save org");
+      }
+      showToast(form.dataset.mode === "create" ? "Org created" : "Org updated");
+      window.location.reload();
+    } catch (error) {
+      showToast(error.message, "danger");
+    }
+  });
+
+  document.querySelectorAll(".org-edit").forEach((button) => {
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      const row = button.closest("tr");
+      const environment = row.dataset.environment;
+      form.dataset.mode = "edit";
+      form.dataset.orgId = row.dataset.org;
+      document.getElementById("org-id").value = row.children[0].textContent.trim();
+      document.getElementById("org-label").value = row.children[1].textContent.trim();
+      document.getElementById("org-client-id").value = row.dataset.clientId;
+      document.getElementById("org-redirect-uri").value = row.dataset.redirectUri;
+      document.getElementById("org-scope").value = row.dataset.scope;
+      document.getElementById("org-client-secret").value = "";
+      document.getElementById("org-form-submit").textContent = "Update org";
+      if (environment === "production" || environment === "sandbox") {
+        environmentSelect.value = environment;
+        customEnvironmentInput.value = "";
+      } else {
+        environmentSelect.value = "custom";
+        customEnvironmentInput.value = environment;
+      }
+      updateCustomEnvironmentVisibility(environmentSelect);
+      document.getElementById("org-label").focus();
+    });
+  });
+
+  document.querySelectorAll(".org-delete").forEach((button) => {
+    button.addEventListener("click", async (event) => {
+      event.preventDefault();
+      const row = button.closest("tr");
+      const orgId = row.dataset.org;
+      if (!confirm(`Delete org ${orgId}?`)) return;
+      const response = await fetch(`/api/orgs/${orgId}`, { method: "DELETE" });
+      if (response.ok) {
+        showToast("Org deleted", "info");
+        row.remove();
+        resetOrgForm(form);
+      } else {
+        showToast("Failed to delete org", "danger");
+      }
+    });
+  });
+
+  updateCustomEnvironmentVisibility(environmentSelect);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  bindOrgSelection();
+  bindQueryForm();
+  bindOrgForm();
+});

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,12 @@
+body {
+  min-height: 100vh;
+}
+
+.org-select.active {
+  border-color: #0d6efd;
+  background-color: rgba(13, 110, 253, 0.1);
+}
+
+#query-result {
+  min-height: 150px;
+}

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DATA_FILE = Path(__file__).resolve().parent.parent / "data" / "orgs.json"
+
+_lock = threading.Lock()
+
+
+@dataclass
+class OrgConfig:
+    id: str
+    label: str
+    client_id: str
+    client_secret: str
+    environment: str
+    redirect_uri: str
+    auth_scope: str = "full refresh_token"
+    instance_url: Optional[str] = None
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+
+    @property
+    def login_url(self) -> str:
+        if self.environment == "production":
+            return "https://login.salesforce.com"
+        if self.environment == "sandbox":
+            return "https://test.salesforce.com"
+        return self.environment
+
+
+class OrgStorage:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def load_all(self) -> Dict[str, OrgConfig]:
+        if not self.path.exists():
+            return {}
+        with self.path.open("r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+        return {item["id"]: OrgConfig(**item) for item in raw}
+
+    def save_all(self, orgs: Dict[str, OrgConfig]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump([asdict(org) for org in orgs.values()], fh, indent=2, sort_keys=True)
+
+    def upsert(self, org: OrgConfig) -> OrgConfig:
+        with _lock:
+            orgs = self.load_all()
+            orgs[org.id] = org
+            self.save_all(orgs)
+            return org
+
+    def delete(self, org_id: str) -> None:
+        with _lock:
+            orgs = self.load_all()
+            if org_id in orgs:
+                del orgs[org_id]
+                self.save_all(orgs)
+
+    def get(self, org_id: str) -> Optional[OrgConfig]:
+        return self.load_all().get(org_id)
+
+    def list(self) -> List[OrgConfig]:
+        return list(self.load_all().values())
+
+
+def ensure_storage() -> None:
+    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if not DATA_FILE.exists():
+        DATA_FILE.write_text("[]", encoding="utf-8")
+
+
+storage = OrgStorage(DATA_FILE)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ title or "SF Integrator" }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+      <div class="container">
+        <a class="navbar-brand" href="{{ url_for('main.index') }}">SF Integrator</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('main.index') }}">Query</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('main.manage_orgs') }}">Org Configuration</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('main.guide') }}">Guide</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container mb-5">
+      {% block content %}{% endblock %}
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="{{ url_for('static', filename='app.js') }}" defer></script>
+  </body>
+</html>

--- a/app/templates/guide.html
+++ b/app/templates/guide.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h3 class="card-title">Salesforce OAuth Integration Checklist</h3>
+    <p class="text-muted">Follow these steps to connect this app with your Salesforce org.</p>
+
+    <h5>1. Prepare Salesforce</h5>
+    <ol>
+      <li>Sign in to the Salesforce org that you want to integrate.</li>
+      <li>Navigate to <strong>Setup &gt; Apps &gt; App Manager</strong> and click <em>New Connected App</em>.</li>
+      <li>Give the app a meaningful name, supply an email, and enable <strong>OAuth Settings for API Integration</strong>.</li>
+      <li>Set the <strong>Callback URL</strong> to <code>https://your-host/oauth/callback</code> (update it to match your deployment URL).</li>
+      <li>Select the following OAuth scopes: <code>Full access (full)</code> and <code>Perform requests on your behalf at any time (refresh_token, offline_access)</code>.</li>
+      <li>Save the connected app and copy the <strong>Consumer Key</strong> and <strong>Consumer Secret</strong>.</li>
+      <li>Under <strong>Manage &gt; OAuth Policies</strong>, ensure that the refresh token policy allows refresh token usage.</li>
+    </ol>
+
+    <h5>2. Configure the integrator</h5>
+    <ol>
+      <li>Open the <a href="{{ url_for('main.manage_orgs') }}">Org Configuration</a> page.</li>
+      <li>Fill in the form with:
+        <ul>
+          <li><strong>Org ID</strong>: an internal identifier such as <code>prod</code> or <code>dev</code>.</li>
+          <li><strong>Display name</strong>: friendly name shown in the UI.</li>
+          <li><strong>Environment</strong>: choose Production, Sandbox, or enter your custom My Domain URL.</li>
+          <li><strong>Consumer Key</strong> and <strong>Consumer Secret</strong> from the connected app.</li>
+          <li><strong>Redirect URI</strong>: must match the callback URL configured in Salesforce.</li>
+          <li><strong>OAuth Scope</strong>: default is <code>full refresh_token</code>; adjust if needed.</li>
+        </ul>
+      </li>
+      <li>Click <strong>Save org</strong>.</li>
+      <li>Use the <strong>Connect</strong> button in the table to start OAuth authorization.</li>
+      <li>Grant access in Salesforce when prompted; you will be redirected back to the app.</li>
+    </ol>
+
+    <h5>3. Run SOQL queries</h5>
+    <ol>
+      <li>Return to the <a href="{{ url_for('main.index') }}">Query</a> page.</li>
+      <li>Select the org you just authorized and paste a SOQL query, e.g. <code>SELECT Id, Name FROM Account LIMIT 10</code>.</li>
+      <li>Click <strong>Run query</strong> to execute. Results appear in a table below the form.</li>
+    </ol>
+
+    <div class="alert alert-info mt-4">
+      <strong>Tip:</strong> For local development, set your callback URL to <code>http://localhost:5000/oauth/callback</code> and add it to the connected app's list of allowed callbacks.
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row">
+  <div class="col-lg-4">
+    <div class="card shadow-sm mb-4">
+      <div class="card-body">
+        <h5 class="card-title">Select an org</h5>
+        <p class="card-text">Choose a configured org to run SOQL queries.</p>
+        <div id="org-list">
+          {% if orgs %}
+            <div class="list-group">
+              {% for org in orgs %}
+                <button type="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center org-select" data-org="{{ org.id }}">
+                  <span>
+                    <strong>{{ org.label }}</strong>
+                    <span class="d-block small text-muted">{{ org.environment }}</span>
+                  </span>
+                  {% if org.access_token %}
+                    <span class="badge bg-success">Connected</span>
+                  {% else %}
+                    <span class="badge bg-secondary">Not connected</span>
+                  {% endif %}
+                </button>
+              {% endfor %}
+            </div>
+          {% else %}
+            <p class="text-muted">No orgs yet. Add one from the org configuration page.</p>
+          {% endif %}
+        </div>
+        <a class="btn btn-outline-primary mt-3" href="{{ url_for('main.manage_orgs') }}">Manage orgs</a>
+      </div>
+    </div>
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h6 class="card-title">Need help?</h6>
+        <p class="card-text">Follow the configuration checklist.</p>
+        <a class="btn btn-sm btn-primary" href="{{ url_for('main.guide') }}">View guide</a>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-8">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h5 class="card-title">SOQL Explorer</h5>
+        <form id="query-form" class="mb-3">
+          <div class="mb-3">
+            <label class="form-label" for="selected-org">Selected Org</label>
+            <input id="selected-org" class="form-control" type="text" placeholder="Select an org" readonly />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="soql-query">SOQL Query</label>
+            <textarea id="soql-query" class="form-control" rows="5" placeholder="SELECT Id, Name FROM Account"></textarea>
+          </div>
+          <button type="submit" class="btn btn-primary">Run query</button>
+        </form>
+        <div id="query-result" class="table-responsive"></div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/orgs.html
+++ b/app/templates/orgs.html
@@ -1,0 +1,107 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row">
+  <div class="col-lg-5">
+    <div class="card shadow-sm mb-4">
+      <div class="card-body">
+        <h5 class="card-title">Add or update an org</h5>
+        <form id="org-form">
+          <div class="mb-3">
+            <label class="form-label" for="org-id">Org ID</label>
+            <input class="form-control" id="org-id" required placeholder="unique-id" />
+            <div class="form-text">Use a unique identifier (e.g. prod, sandbox1).</div>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="org-label">Display name</label>
+            <input class="form-control" id="org-label" required placeholder="Production Org" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="org-environment">Environment</label>
+            <select class="form-select" id="org-environment" required>
+              <option value="production">Production (login.salesforce.com)</option>
+              <option value="sandbox">Sandbox (test.salesforce.com)</option>
+              <option value="custom">Custom Domain</option>
+            </select>
+            <input class="form-control mt-2 d-none" id="org-custom-environment" placeholder="https://your-domain.my.salesforce.com" />
+            <div class="form-text">Select custom to use a My Domain login URL.</div>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="org-client-id">Consumer Key (Client ID)</label>
+            <input class="form-control" id="org-client-id" required />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="org-client-secret">Consumer Secret</label>
+            <input class="form-control" id="org-client-secret" />
+            <div class="form-text">Leave blank to keep the existing secret when editing.</div>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="org-redirect-uri">Redirect URI</label>
+            <input class="form-control" id="org-redirect-uri" placeholder="https://yourapp.com/oauth/callback" required />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="org-scope">OAuth Scope</label>
+            <input class="form-control" id="org-scope" value="full refresh_token" />
+          </div>
+          <button class="btn btn-primary" id="org-form-submit" type="submit">Save org</button>
+          <button class="btn btn-link" id="org-form-reset" type="button">Clear form</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-7">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h5 class="card-title">Configured orgs</h5>
+        <div id="org-table-container">
+          {% if orgs %}
+            <div class="table-responsive">
+              <table class="table table-striped align-middle">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Label</th>
+                    <th>Environment</th>
+                    <th>Status</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for org in orgs %}
+                    <tr
+                      data-org="{{ org.id }}"
+                      data-environment="{{ org.environment }}"
+                      data-client-id="{{ org.client_id }}"
+                      data-redirect-uri="{{ org.redirect_uri }}"
+                      data-scope="{{ org.auth_scope }}"
+                    >
+                      <td>{{ org.id }}</td>
+                      <td>{{ org.label }}</td>
+                      <td>{{ org.environment }}</td>
+                      <td>
+                        {% if org.access_token %}
+                          <span class="badge bg-success">Connected</span>
+                        {% else %}
+                          <span class="badge bg-secondary">Not connected</span>
+                        {% endif %}
+                      </td>
+                      <td class="text-end">
+                        <div class="btn-group btn-group-sm">
+                          <a class="btn btn-outline-primary" href="{{ url_for('main.start_auth', org_id=org.id) }}">Connect</a>
+                          <button class="btn btn-outline-secondary org-edit">Edit</button>
+                          <button class="btn btn-outline-danger org-delete">Delete</button>
+                        </div>
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% else %}
+            <p class="text-muted">No orgs configured yet.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+requests==2.31.0


### PR DESCRIPTION
## Summary
- build a Flask web app for configuring Salesforce orgs, running OAuth 2.0 flows, and executing SOQL queries
- add HTML templates and JavaScript for org management, query execution, and a configuration guide
- implement Salesforce API helper logic with token storage plus project documentation and dependencies

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68db8b297280832497aa852f620abae6