### PR TITLE
Add helper script that provisions and uses a venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ A lightweight Flask application to manage Salesforce org connections via OAuth 2
    pip install -r requirements.txt
    ```
 
-3. Set the Flask app and run the development server:
+3. (Optional) Use the helper script to create/activate a virtual environment,
+   install dependencies, and start the server automatically:
+
+   ```bash
+   ./setup_and_run.sh
+   ```
+
+   The script will create `./venv` if it does not already exist.
+
+4. To run the app manually, set the Flask app and start the development server:
 
    ```bash
    export FLASK_APP=app

--- a/setup_and_run.sh
+++ b/setup_and_run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the directory where this script lives so that all commands
+# operate relative to the project root regardless of the caller's cwd.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VENV_DIR="$SCRIPT_DIR/venv"
+
+# Prefer python3 when available, otherwise fall back to python.
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON="python"
+else
+    echo "Python is not installed or not on PATH." >&2
+    exit 1
+fi
+
+# Create the virtual environment if it does not already exist.
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating Python virtual environment..."
+    "$PYTHON" -m venv "$VENV_DIR"
+fi
+
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+# Upgrade pip to ensure reliable installs.
+echo "Upgrading pip..."
+python -m pip install --upgrade pip
+
+echo "Installing project dependencies..."
+pip install -r "$SCRIPT_DIR/requirements.txt"
+
+export FLASK_APP=app
+
+echo "Starting Flask development server..."
+flask run


### PR DESCRIPTION
## Summary
- add a POSIX helper script that provisions a virtual environment, installs dependencies, and starts the Flask server
- document the helper script in the README so developers know it automatically manages the venv

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db92a9e51c83249da8847a6ee8756d