### PR TITLE
Add language settings and Italian localization

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict
+
+
+DEFAULT_LANGUAGE = "en"
+
+
+_LANGUAGE_PACKS: Dict[str, Dict[str, Any]] = {
+    "en": {
+        "language_name": "English",
+        "app": {"title": "SF Integrator"},
+        "nav": {
+            "brand": "SF Integrator",
+            "query": "Query",
+            "org_config": "Org Configuration",
+            "guide": "Guide",
+            "settings": "Settings",
+        },
+        "index": {
+            "select_org": {
+                "title": "Select an org",
+                "description": "Choose a configured org to run SOQL queries.",
+                "connected_badge": "Connected",
+                "not_connected_badge": "Not connected",
+                "empty": "No orgs yet. Add one from the org configuration page.",
+                "manage_button": "Manage orgs",
+            },
+            "help": {
+                "title": "Need help?",
+                "description": "Follow the configuration checklist.",
+                "guide_button": "View guide",
+            },
+            "query": {
+                "title": "SOQL Explorer",
+                "selected_org_label": "Selected Org",
+                "selected_org_placeholder": "Select an org",
+                "soql_label": "SOQL Query",
+                "soql_placeholder": "SELECT Id, Name FROM Account",
+                "run_button": "Run query",
+            },
+        },
+        "orgs": {
+            "form": {
+                "title": "Add or update an org",
+                "id_label": "Org ID",
+                "id_placeholder": "unique-id",
+                "id_help": "Use a unique identifier (e.g. prod, sandbox1).",
+                "label_label": "Display name",
+                "label_placeholder": "Production Org",
+                "environment_label": "Environment",
+                "environment_production": "Production (login.salesforce.com)",
+                "environment_sandbox": "Sandbox (test.salesforce.com)",
+                "environment_custom": "Custom Domain",
+                "environment_custom_placeholder": "https://your-domain.my.salesforce.com",
+                "environment_help": "Select custom to use a My Domain login URL.",
+                "client_id_label": "Consumer Key (Client ID)",
+                "client_secret_label": "Consumer Secret",
+                "client_secret_help": "Leave blank to keep the existing secret when editing.",
+                "redirect_uri_label": "Redirect URI",
+                "redirect_uri_placeholder": "https://yourapp.com/oauth/callback",
+                "scope_label": "OAuth Scope",
+                "scope_default": "full refresh_token",
+                "save_button": "Save org",
+                "clear_button": "Clear form",
+                "update_button": "Update org",
+            },
+            "table": {
+                "title": "Configured orgs",
+                "empty": "No orgs configured yet.",
+                "headers": {
+                    "id": "ID",
+                    "label": "Label",
+                    "environment": "Environment",
+                    "status": "Status",
+                    "actions": "",
+                },
+                "connected_badge": "Connected",
+                "not_connected_badge": "Not connected",
+                "actions": {
+                    "connect": "Connect",
+                    "edit": "Edit",
+                    "delete": "Delete",
+                },
+            },
+        },
+        "guide": {
+            "title": "Salesforce OAuth Integration Checklist",
+            "subtitle": "Follow these steps to connect this app with your Salesforce org.",
+            "sections": {
+                "prepare": {
+                    "title": "1. Prepare Salesforce",
+                    "steps": [
+                        "Sign in to the Salesforce org that you want to integrate.",
+                        "Navigate to <strong>Setup &gt; Apps &gt; App Manager</strong> and click <strong>New Connected App</strong> (Lightning Experience) rather than <em>New Lightning App</em> or <em>New External Client App</em>.",
+                        "Fill out the basic information section: enter a descriptive <strong>Connected App Name</strong>, allow Salesforce to auto-populate the <strong>API Name</strong>, and provide a <strong>Contact Email</strong>; the remaining optional fields can stay blank unless your org requires them.",
+                        "Enable <strong>OAuth Settings for API Integration</strong> to reveal the integration options.",
+                        "Within the OAuth settings, leave <strong>Require Secret for Web Server Flow</strong> checked, keep the default <strong>Selected OAuth Scopes</strong> list empty for now, and skip optional fields such as <em>Start URL</em> or <em>Callback URL for Lightning Apps</em>.",
+                        "Set the primary <strong>Callback URL</strong> to <code>http://localhost:5000/oauth/callback</code> for local development; when deploying, replace <code>localhost:5000</code> with your host name while keeping the path <code>/oauth/callback</code>.",
+                        "Add the following OAuth scopes to the <strong>Selected OAuth Scopes</strong> list: <code>Full access (full)</code> and <code>Perform requests on your behalf at any time (refresh_token, offline_access)</code>. Other scopes can remain unselected unless your integration needs them.",
+                        "Save the connected app and copy the <strong>Consumer Key</strong> and <strong>Consumer Secret</strong>.",
+                        "Under <strong>Manage &gt; OAuth Policies</strong>, ensure that the refresh token policy allows refresh token usage.",
+                    ],
+                },
+                "configure": {
+                    "title": "2. Configure the integrator",
+                    "steps": [
+                        "Open the <a href=\"{org_config_url}\">Org Configuration</a> page.",
+                        "Fill in the form with:",
+                        "Click <strong>Save org</strong>.",
+                        "Use the <strong>Connect</strong> button in the table to start OAuth authorization.",
+                        "Grant access in Salesforce when prompted; you will be redirected back to the app.",
+                    ],
+                    "form_details": [
+                        "<strong>Org ID</strong>: an internal identifier such as <code>prod</code> or <code>dev</code>.",
+                        "<strong>Display name</strong>: friendly name shown in the UI.",
+                        "<strong>Environment</strong>: choose Production, Sandbox, or enter your custom My Domain URL.",
+                        "<strong>Consumer Key</strong> and <strong>Consumer Secret</strong> from the connected app.",
+                        "<strong>Redirect URI</strong>: must match the callback URL configured in Salesforce.",
+                        "<strong>OAuth Scope</strong>: default is <code>full refresh_token</code>; adjust if needed.",
+                    ],
+                },
+                "query": {
+                    "title": "3. Run SOQL queries",
+                    "steps": [
+                        "Return to the <a href=\"{query_url}\">Query</a> page.",
+                        "Select the org you just authorized and paste a SOQL query, e.g. <code>SELECT Id, Name FROM Account LIMIT 10</code>.",
+                        "Click <strong>Run query</strong> to execute. Results appear in a table below the form.",
+                    ],
+                },
+            },
+            "tip": {
+                "title": "Tip:",
+                "content": "For local development, set your callback URL to <code>http://localhost:5000/oauth/callback</code> and add it to the connected app's list of allowed callbacks. When deploying, update the host name to match your environment but keep the path <code>/oauth/callback</code> so the redirect completes successfully.",
+            },
+        },
+        "settings": {
+            "title": "Settings",
+            "language_label": "Language",
+            "language_submit": "Save settings",
+            "language_saved": "Language updated successfully.",
+        },
+        "frontend": {
+            "toast": {
+                "select_org": "Select an org before running a query",
+                "enter_query": "Enter a SOQL query",
+                "query_failed": "Query failed",
+                "org_created": "Org created",
+                "org_updated": "Org updated",
+                "org_deleted": "Org deleted",
+                "delete_failed": "Failed to delete org",
+                "fill_required": "Please fill all required fields",
+                "enter_secret": "Enter the consumer secret for new orgs",
+                "save_failed": "Unable to save org",
+            },
+            "query": {"no_records": "No records returned."},
+            "form": {"update_button": "Update org", "save_button": "Save org"},
+            "confirm": {"delete_org": "Delete org {orgId}?"},
+        },
+    },
+    "it": {
+        "language_name": "Italiano",
+        "app": {"title": "SF Integrator"},
+        "nav": {
+            "brand": "SF Integrator",
+            "query": "Query",
+            "org_config": "Configurazione org",
+            "guide": "Guida",
+            "settings": "Impostazioni",
+        },
+        "index": {
+            "select_org": {
+                "title": "Seleziona un'organizzazione",
+                "description": "Scegli un'organizzazione configurata per eseguire query SOQL.",
+                "connected_badge": "Connessa",
+                "not_connected_badge": "Non connessa",
+                "empty": "Nessuna organizzazione disponibile. Aggiungine una dalla pagina di configurazione.",
+                "manage_button": "Gestisci organizzazioni",
+            },
+            "help": {
+                "title": "Serve aiuto?",
+                "description": "Segui la checklist di configurazione.",
+                "guide_button": "Apri la guida",
+            },
+            "query": {
+                "title": "Esploratore SOQL",
+                "selected_org_label": "Organizzazione selezionata",
+                "selected_org_placeholder": "Seleziona un'organizzazione",
+                "soql_label": "Query SOQL",
+                "soql_placeholder": "SELECT Id, Name FROM Account",
+                "run_button": "Esegui query",
+            },
+        },
+        "orgs": {
+            "form": {
+                "title": "Aggiungi o aggiorna un'organizzazione",
+                "id_label": "ID organizzazione",
+                "id_placeholder": "id-univoco",
+                "id_help": "Usa un identificatore univoco (es. prod, sandbox1).",
+                "label_label": "Nome visualizzato",
+                "label_placeholder": "Org di produzione",
+                "environment_label": "Ambiente",
+                "environment_production": "Produzione (login.salesforce.com)",
+                "environment_sandbox": "Sandbox (test.salesforce.com)",
+                "environment_custom": "Dominio personalizzato",
+                "environment_custom_placeholder": "https://tuo-dominio.my.salesforce.com",
+                "environment_help": "Seleziona personalizzato per usare un URL My Domain.",
+                "client_id_label": "Consumer Key (Client ID)",
+                "client_secret_label": "Consumer Secret",
+                "client_secret_help": "Lascia vuoto per mantenere il secret esistente durante la modifica.",
+                "redirect_uri_label": "Redirect URI",
+                "redirect_uri_placeholder": "https://tuoapp.com/oauth/callback",
+                "scope_label": "Ambito OAuth",
+                "scope_default": "full refresh_token",
+                "save_button": "Salva organizzazione",
+                "clear_button": "Pulisci modulo",
+                "update_button": "Aggiorna organizzazione",
+            },
+            "table": {
+                "title": "Organizzazioni configurate",
+                "empty": "Nessuna organizzazione configurata.",
+                "headers": {
+                    "id": "ID",
+                    "label": "Nome",
+                    "environment": "Ambiente",
+                    "status": "Stato",
+                    "actions": "",
+                },
+                "connected_badge": "Connessa",
+                "not_connected_badge": "Non connessa",
+                "actions": {
+                    "connect": "Connetti",
+                    "edit": "Modifica",
+                    "delete": "Elimina",
+                },
+            },
+        },
+        "guide": {
+            "title": "Lista di controllo per l'integrazione OAuth Salesforce",
+            "subtitle": "Segui questi passaggi per collegare l'app alla tua organizzazione Salesforce.",
+            "sections": {
+                "prepare": {
+                    "title": "1. Prepara Salesforce",
+                    "steps": [
+                        "Accedi all'organizzazione Salesforce che vuoi integrare.",
+                        "Vai su <strong>Setup &gt; Apps &gt; App Manager</strong> e fai clic su <strong>New Connected App</strong> (Lightning Experience) invece di <em>New Lightning App</em> o <em>New External Client App</em>.",
+                        "Compila la sezione delle informazioni di base: inserisci un <strong>Connected App Name</strong> descrittivo, lascia che Salesforce generi automaticamente l'<strong>API Name</strong> e indica un <strong>Contact Email</strong>; i campi opzionali possono rimanere vuoti salvo necessità specifiche.",
+                        "Abilita <strong>OAuth Settings for API Integration</strong> per mostrare le opzioni di integrazione.",
+                        "Nelle impostazioni OAuth lascia selezionato <strong>Require Secret for Web Server Flow</strong>, mantieni vuota la lista <strong>Selected OAuth Scopes</strong> per ora e ignora i campi facoltativi come <em>Start URL</em> o <em>Callback URL for Lightning Apps</em>.",
+                        "Imposta la <strong>Callback URL</strong> principale su <code>http://localhost:5000/oauth/callback</code> per lo sviluppo locale; in produzione sostituisci <code>localhost:5000</code> con il tuo host mantenendo il percorso <code>/oauth/callback</code>.",
+                        "Aggiungi i seguenti ambiti OAuth alla lista <strong>Selected OAuth Scopes</strong>: <code>Full access (full)</code> e <code>Perform requests on your behalf at any time (refresh_token, offline_access)</code>. Altri ambiti possono restare non selezionati salvo necessità.",
+                        "Salva la connected app e copia il <strong>Consumer Key</strong> e il <strong>Consumer Secret</strong>.",
+                        "In <strong>Manage &gt; OAuth Policies</strong> assicurati che la policy sui refresh token ne consenta l'utilizzo.",
+                    ],
+                },
+                "configure": {
+                    "title": "2. Configura l'integratore",
+                    "steps": [
+                        "Apri la pagina <a href=\"{org_config_url}\">Configurazione org</a>.",
+                        "Compila il modulo con:",
+                        "Fai clic su <strong>Salva organizzazione</strong>.",
+                        "Usa il pulsante <strong>Connetti</strong> nella tabella per avviare l'autorizzazione OAuth.",
+                        "Quando richiesto, concedi l'accesso in Salesforce; verrai reindirizzato all'app.",
+                    ],
+                    "form_details": [
+                        "<strong>ID organizzazione</strong>: un identificatore interno come <code>prod</code> o <code>dev</code>.",
+                        "<strong>Nome visualizzato</strong>: il nome mostrato nell'interfaccia.",
+                        "<strong>Ambiente</strong>: scegli Produzione, Sandbox o inserisci il tuo URL My Domain personalizzato.",
+                        "<strong>Consumer Key</strong> e <strong>Consumer Secret</strong> della connected app.",
+                        "<strong>Redirect URI</strong>: deve corrispondere alla callback configurata in Salesforce.",
+                        "<strong>Ambito OAuth</strong>: il valore predefinito è <code>full refresh_token</code>; modificalo se necessario.",
+                    ],
+                },
+                "query": {
+                    "title": "3. Esegui query SOQL",
+                    "steps": [
+                        "Torna alla pagina <a href=\"{query_url}\">Query</a>.",
+                        "Seleziona l'organizzazione appena autorizzata e incolla una query SOQL, ad esempio <code>SELECT Id, Name FROM Account LIMIT 10</code>.",
+                        "Fai clic su <strong>Esegui query</strong> per lanciare l'operazione. I risultati compariranno nella tabella sotto il modulo.",
+                    ],
+                },
+            },
+            "tip": {
+                "title": "Suggerimento:",
+                "content": "Per lo sviluppo locale imposta la callback su <code>http://localhost:5000/oauth/callback</code> e aggiungila all'elenco di callback consentite della connected app. In produzione aggiorna il nome host in base all'ambiente mantenendo il percorso <code>/oauth/callback</code> per completare correttamente il reindirizzamento.",
+            },
+        },
+        "settings": {
+            "title": "Impostazioni",
+            "language_label": "Lingua",
+            "language_submit": "Salva impostazioni",
+            "language_saved": "Lingua aggiornata correttamente.",
+        },
+        "frontend": {
+            "toast": {
+                "select_org": "Seleziona un'organizzazione prima di eseguire una query",
+                "enter_query": "Inserisci una query SOQL",
+                "query_failed": "Query non riuscita",
+                "org_created": "Organizzazione creata",
+                "org_updated": "Organizzazione aggiornata",
+                "org_deleted": "Organizzazione eliminata",
+                "delete_failed": "Impossibile eliminare l'organizzazione",
+                "fill_required": "Compila tutti i campi obbligatori",
+                "enter_secret": "Inserisci il consumer secret per le nuove organizzazioni",
+                "save_failed": "Impossibile salvare l'organizzazione",
+            },
+            "query": {"no_records": "Nessun record restituito."},
+            "form": {"update_button": "Aggiorna organizzazione", "save_button": "Salva organizzazione"},
+            "confirm": {"delete_org": "Eliminare l'organizzazione {orgId}?"},
+        },
+    },
+}
+
+
+def get_language_codes() -> list[str]:
+    return list(_LANGUAGE_PACKS.keys())
+
+
+def get_language_name(code: str) -> str:
+    return _LANGUAGE_PACKS.get(code, {}).get("language_name", code)
+
+
+def get_language_pack(code: str) -> Dict[str, Any]:
+    return deepcopy(_LANGUAGE_PACKS.get(code, _LANGUAGE_PACKS[DEFAULT_LANGUAGE]))
+
+
+def translate(key: str, language: str | None = None) -> str:
+    for code in filter(None, [language, DEFAULT_LANGUAGE]):
+        pack = _LANGUAGE_PACKS.get(code)
+        if not pack:
+            continue
+        value: Any = pack
+        found = True
+        for part in key.split('.'):
+            if isinstance(value, dict) and part in value:
+                value = value[part]
+            else:
+                found = False
+                break
+        if found and isinstance(value, str):
+            return value
+    return key
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    for key, value in override.items():
+        if (
+            key in base
+            and isinstance(base[key], dict)
+            and isinstance(value, dict)
+        ):
+            base[key] = _deep_merge(base[key], value)
+        else:
+            base[key] = deepcopy(value)
+    return base
+
+
+def get_frontend_translations(language: str) -> Dict[str, Any]:
+    base = deepcopy(_LANGUAGE_PACKS[DEFAULT_LANGUAGE].get("frontend", {}))
+    if language == DEFAULT_LANGUAGE:
+        return base
+    language_pack = _LANGUAGE_PACKS.get(language, {})
+    frontend = language_pack.get("frontend", {})
+    return _deep_merge(base, frontend)
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,29 +1,32 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ current_language }}">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{{ title or "SF Integrator" }}</title>
+    <title>{{ title or t('app.title') }}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
   </head>
   <body class="bg-light">
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
       <div class="container">
-        <a class="navbar-brand" href="{{ url_for('main.index') }}">SF Integrator</a>
+        <a class="navbar-brand" href="{{ url_for('main.index') }}">{{ t('nav.brand') }}</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
           <ul class="navbar-nav ms-auto">
             <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('main.index') }}">Query</a>
+              <a class="nav-link" href="{{ url_for('main.index') }}">{{ t('nav.query') }}</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('main.manage_orgs') }}">Org Configuration</a>
+              <a class="nav-link" href="{{ url_for('main.manage_orgs') }}">{{ t('nav.org_config') }}</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('main.guide') }}">Guide</a>
+              <a class="nav-link" href="{{ url_for('main.guide') }}">{{ t('nav.guide') }}</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('main.settings') }}">{{ t('nav.settings') }}</a>
             </li>
           </ul>
         </div>
@@ -35,6 +38,10 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script>
+      window.APP_TRANSLATIONS = {{ frontend_translations_json | safe }};
+      window.APP_LANGUAGE = "{{ current_language }}";
+    </script>
     <script src="{{ url_for('static', filename='app.js') }}" defer></script>
   </body>
 </html>

--- a/app/templates/guide.html
+++ b/app/templates/guide.html
@@ -1,50 +1,47 @@
 {% extends 'base.html' %}
 {% block content %}
+{% set guide = language_pack['guide'] %}
+{% set sections = guide['sections'] %}
 <div class="card shadow-sm">
   <div class="card-body">
-    <h3 class="card-title">Salesforce OAuth Integration Checklist</h3>
-    <p class="text-muted">Follow these steps to connect this app with your Salesforce org.</p>
+    <h3 class="card-title">{{ guide['title'] }}</h3>
+    <p class="text-muted">{{ guide['subtitle'] }}</p>
 
-    <h5>1. Prepare Salesforce</h5>
+    <h5>{{ sections['prepare']['title'] }}</h5>
     <ol>
-      <li>Sign in to the Salesforce org that you want to integrate.</li>
-      <li>Navigate to <strong>Setup &gt; Apps &gt; App Manager</strong> and click <strong>New Connected App</strong> (Lightning Experience) rather than <em>New Lightning App</em> or <em>New External Client App</em>.</li>
-      <li>Fill out the basic information section: enter a descriptive <strong>Connected App Name</strong>, allow Salesforce to auto-populate the <strong>API Name</strong>, and provide a <strong>Contact Email</strong>; the remaining optional fields can stay blank unless your org requires them.</li>
-      <li>Enable <strong>OAuth Settings for API Integration</strong> to reveal the integration options.</li>
-      <li>Within the OAuth settings, leave <strong>Require Secret for Web Server Flow</strong> checked, keep the default <strong>Selected OAuth Scopes</strong> list empty for now, and skip optional fields such as <em>Start URL</em> or <em>Callback URL for Lightning Apps</em>.</li>
-      <li>Set the primary <strong>Callback URL</strong> to <code>http://localhost:5000/oauth/callback</code> for local development; when deploying, replace <code>localhost:5000</code> with your host name while keeping the path <code>/oauth/callback</code>.</li>
-      <li>Add the following OAuth scopes to the <strong>Selected OAuth Scopes</strong> list: <code>Full access (full)</code> and <code>Perform requests on your behalf at any time (refresh_token, offline_access)</code>. Other scopes can remain unselected unless your integration needs them.</li>
-      <li>Save the connected app and copy the <strong>Consumer Key</strong> and <strong>Consumer Secret</strong>.</li>
-      <li>Under <strong>Manage &gt; OAuth Policies</strong>, ensure that the refresh token policy allows refresh token usage.</li>
+      {% for step in sections['prepare']['steps'] %}
+        <li>{{ step|format(org_config_url=url_for('main.manage_orgs'), query_url=url_for('main.index'))|safe }}</li>
+      {% endfor %}
     </ol>
 
-    <h5>2. Configure the integrator</h5>
+    <h5>{{ sections['configure']['title'] }}</h5>
     <ol>
-      <li>Open the <a href="{{ url_for('main.manage_orgs') }}">Org Configuration</a> page.</li>
-      <li>Fill in the form with:
-        <ul>
-          <li><strong>Org ID</strong>: an internal identifier such as <code>prod</code> or <code>dev</code>.</li>
-          <li><strong>Display name</strong>: friendly name shown in the UI.</li>
-          <li><strong>Environment</strong>: choose Production, Sandbox, or enter your custom My Domain URL.</li>
-          <li><strong>Consumer Key</strong> and <strong>Consumer Secret</strong> from the connected app.</li>
-          <li><strong>Redirect URI</strong>: must match the callback URL configured in Salesforce.</li>
-          <li><strong>OAuth Scope</strong>: default is <code>full refresh_token</code>; adjust if needed.</li>
-        </ul>
-      </li>
-      <li>Click <strong>Save org</strong>.</li>
-      <li>Use the <strong>Connect</strong> button in the table to start OAuth authorization.</li>
-      <li>Grant access in Salesforce when prompted; you will be redirected back to the app.</li>
+      {% for step in sections['configure']['steps'] %}
+        {% set formatted_step = step|format(org_config_url=url_for('main.manage_orgs')) %}
+        <li>
+          {% if loop.index == 2 %}
+            {{ formatted_step|safe }}
+            <ul>
+              {% for detail in sections['configure']['form_details'] %}
+                <li>{{ detail|safe }}</li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            {{ formatted_step|safe }}
+          {% endif %}
+        </li>
+      {% endfor %}
     </ol>
 
-    <h5>3. Run SOQL queries</h5>
+    <h5>{{ sections['query']['title'] }}</h5>
     <ol>
-      <li>Return to the <a href="{{ url_for('main.index') }}">Query</a> page.</li>
-      <li>Select the org you just authorized and paste a SOQL query, e.g. <code>SELECT Id, Name FROM Account LIMIT 10</code>.</li>
-      <li>Click <strong>Run query</strong> to execute. Results appear in a table below the form.</li>
+      {% for step in sections['query']['steps'] %}
+        <li>{{ step|format(query_url=url_for('main.index'))|safe }}</li>
+      {% endfor %}
     </ol>
 
     <div class="alert alert-info mt-4">
-      <strong>Tip:</strong> For local development, set your callback URL to <code>http://localhost:5000/oauth/callback</code> and add it to the connected app's list of allowed callbacks. When deploying, update the host name to match your environment but keep the path <code>/oauth/callback</code> so the redirect completes successfully.
+      <strong>{{ guide['tip']['title'] }}</strong> {{ guide['tip']['content']|safe }}
     </div>
   </div>
 </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,8 +4,8 @@
   <div class="col-lg-4">
     <div class="card shadow-sm mb-4">
       <div class="card-body">
-        <h5 class="card-title">Select an org</h5>
-        <p class="card-text">Choose a configured org to run SOQL queries.</p>
+        <h5 class="card-title">{{ t('index.select_org.title') }}</h5>
+        <p class="card-text">{{ t('index.select_org.description') }}</p>
         <div id="org-list">
           {% if orgs %}
             <div class="list-group">
@@ -16,42 +16,42 @@
                     <span class="d-block small text-muted">{{ org.environment }}</span>
                   </span>
                   {% if org.access_token %}
-                    <span class="badge bg-success">Connected</span>
+                    <span class="badge bg-success">{{ t('index.select_org.connected_badge') }}</span>
                   {% else %}
-                    <span class="badge bg-secondary">Not connected</span>
+                    <span class="badge bg-secondary">{{ t('index.select_org.not_connected_badge') }}</span>
                   {% endif %}
                 </button>
               {% endfor %}
             </div>
           {% else %}
-            <p class="text-muted">No orgs yet. Add one from the org configuration page.</p>
+            <p class="text-muted">{{ t('index.select_org.empty') }}</p>
           {% endif %}
         </div>
-        <a class="btn btn-outline-primary mt-3" href="{{ url_for('main.manage_orgs') }}">Manage orgs</a>
+        <a class="btn btn-outline-primary mt-3" href="{{ url_for('main.manage_orgs') }}">{{ t('index.select_org.manage_button') }}</a>
       </div>
     </div>
     <div class="card shadow-sm">
       <div class="card-body">
-        <h6 class="card-title">Need help?</h6>
-        <p class="card-text">Follow the configuration checklist.</p>
-        <a class="btn btn-sm btn-primary" href="{{ url_for('main.guide') }}">View guide</a>
+        <h6 class="card-title">{{ t('index.help.title') }}</h6>
+        <p class="card-text">{{ t('index.help.description') }}</p>
+        <a class="btn btn-sm btn-primary" href="{{ url_for('main.guide') }}">{{ t('index.help.guide_button') }}</a>
       </div>
     </div>
   </div>
   <div class="col-lg-8">
     <div class="card shadow-sm">
       <div class="card-body">
-        <h5 class="card-title">SOQL Explorer</h5>
+        <h5 class="card-title">{{ t('index.query.title') }}</h5>
         <form id="query-form" class="mb-3">
           <div class="mb-3">
-            <label class="form-label" for="selected-org">Selected Org</label>
-            <input id="selected-org" class="form-control" type="text" placeholder="Select an org" readonly />
+            <label class="form-label" for="selected-org">{{ t('index.query.selected_org_label') }}</label>
+            <input id="selected-org" class="form-control" type="text" placeholder="{{ t('index.query.selected_org_placeholder') }}" readonly />
           </div>
           <div class="mb-3">
-            <label class="form-label" for="soql-query">SOQL Query</label>
-            <textarea id="soql-query" class="form-control" rows="5" placeholder="SELECT Id, Name FROM Account"></textarea>
+            <label class="form-label" for="soql-query">{{ t('index.query.soql_label') }}</label>
+            <textarea id="soql-query" class="form-control" rows="5" placeholder="{{ t('index.query.soql_placeholder') }}"></textarea>
           </div>
-          <button type="submit" class="btn btn-primary">Run query</button>
+          <button type="submit" class="btn btn-primary">{{ t('index.query.run_button') }}</button>
         </form>
         <div id="query-result" class="table-responsive"></div>
       </div>

--- a/app/templates/orgs.html
+++ b/app/templates/orgs.html
@@ -4,46 +4,46 @@
   <div class="col-lg-5">
     <div class="card shadow-sm mb-4">
       <div class="card-body">
-        <h5 class="card-title">Add or update an org</h5>
+        <h5 class="card-title">{{ t('orgs.form.title') }}</h5>
         <form id="org-form">
           <div class="mb-3">
-            <label class="form-label" for="org-id">Org ID</label>
-            <input class="form-control" id="org-id" required placeholder="unique-id" />
-            <div class="form-text">Use a unique identifier (e.g. prod, sandbox1).</div>
+            <label class="form-label" for="org-id">{{ t('orgs.form.id_label') }}</label>
+            <input class="form-control" id="org-id" required placeholder="{{ t('orgs.form.id_placeholder') }}" />
+            <div class="form-text">{{ t('orgs.form.id_help') }}</div>
           </div>
           <div class="mb-3">
-            <label class="form-label" for="org-label">Display name</label>
-            <input class="form-control" id="org-label" required placeholder="Production Org" />
+            <label class="form-label" for="org-label">{{ t('orgs.form.label_label') }}</label>
+            <input class="form-control" id="org-label" required placeholder="{{ t('orgs.form.label_placeholder') }}" />
           </div>
           <div class="mb-3">
-            <label class="form-label" for="org-environment">Environment</label>
+            <label class="form-label" for="org-environment">{{ t('orgs.form.environment_label') }}</label>
             <select class="form-select" id="org-environment" required>
-              <option value="production">Production (login.salesforce.com)</option>
-              <option value="sandbox">Sandbox (test.salesforce.com)</option>
-              <option value="custom">Custom Domain</option>
+              <option value="production">{{ t('orgs.form.environment_production') }}</option>
+              <option value="sandbox">{{ t('orgs.form.environment_sandbox') }}</option>
+              <option value="custom">{{ t('orgs.form.environment_custom') }}</option>
             </select>
-            <input class="form-control mt-2 d-none" id="org-custom-environment" placeholder="https://your-domain.my.salesforce.com" />
-            <div class="form-text">Select custom to use a My Domain login URL.</div>
+            <input class="form-control mt-2 d-none" id="org-custom-environment" placeholder="{{ t('orgs.form.environment_custom_placeholder') }}" />
+            <div class="form-text">{{ t('orgs.form.environment_help') }}</div>
           </div>
           <div class="mb-3">
-            <label class="form-label" for="org-client-id">Consumer Key (Client ID)</label>
+            <label class="form-label" for="org-client-id">{{ t('orgs.form.client_id_label') }}</label>
             <input class="form-control" id="org-client-id" required />
           </div>
           <div class="mb-3">
-            <label class="form-label" for="org-client-secret">Consumer Secret</label>
+            <label class="form-label" for="org-client-secret">{{ t('orgs.form.client_secret_label') }}</label>
             <input class="form-control" id="org-client-secret" />
-            <div class="form-text">Leave blank to keep the existing secret when editing.</div>
+            <div class="form-text">{{ t('orgs.form.client_secret_help') }}</div>
           </div>
           <div class="mb-3">
-            <label class="form-label" for="org-redirect-uri">Redirect URI</label>
-            <input class="form-control" id="org-redirect-uri" placeholder="https://yourapp.com/oauth/callback" required />
+            <label class="form-label" for="org-redirect-uri">{{ t('orgs.form.redirect_uri_label') }}</label>
+            <input class="form-control" id="org-redirect-uri" placeholder="{{ t('orgs.form.redirect_uri_placeholder') }}" required />
           </div>
           <div class="mb-3">
-            <label class="form-label" for="org-scope">OAuth Scope</label>
-            <input class="form-control" id="org-scope" value="full refresh_token" />
+            <label class="form-label" for="org-scope">{{ t('orgs.form.scope_label') }}</label>
+            <input class="form-control" id="org-scope" value="{{ t('orgs.form.scope_default') }}" />
           </div>
-          <button class="btn btn-primary" id="org-form-submit" type="submit">Save org</button>
-          <button class="btn btn-link" id="org-form-reset" type="button">Clear form</button>
+          <button class="btn btn-primary" id="org-form-submit" type="submit">{{ t('orgs.form.save_button') }}</button>
+          <button class="btn btn-link" id="org-form-reset" type="button">{{ t('orgs.form.clear_button') }}</button>
         </form>
       </div>
     </div>
@@ -51,18 +51,18 @@
   <div class="col-lg-7">
     <div class="card shadow-sm">
       <div class="card-body">
-        <h5 class="card-title">Configured orgs</h5>
+        <h5 class="card-title">{{ t('orgs.table.title') }}</h5>
         <div id="org-table-container">
           {% if orgs %}
             <div class="table-responsive">
               <table class="table table-striped align-middle">
                 <thead>
                   <tr>
-                    <th>ID</th>
-                    <th>Label</th>
-                    <th>Environment</th>
-                    <th>Status</th>
-                    <th></th>
+                    <th>{{ t('orgs.table.headers.id') }}</th>
+                    <th>{{ t('orgs.table.headers.label') }}</th>
+                    <th>{{ t('orgs.table.headers.environment') }}</th>
+                    <th>{{ t('orgs.table.headers.status') }}</th>
+                    <th>{{ t('orgs.table.headers.actions') }}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -79,16 +79,16 @@
                       <td>{{ org.environment }}</td>
                       <td>
                         {% if org.access_token %}
-                          <span class="badge bg-success">Connected</span>
+                          <span class="badge bg-success">{{ t('orgs.table.connected_badge') }}</span>
                         {% else %}
-                          <span class="badge bg-secondary">Not connected</span>
+                          <span class="badge bg-secondary">{{ t('orgs.table.not_connected_badge') }}</span>
                         {% endif %}
                       </td>
                       <td class="text-end">
                         <div class="btn-group btn-group-sm">
-                          <a class="btn btn-outline-primary" href="{{ url_for('main.start_auth', org_id=org.id) }}">Connect</a>
-                          <button class="btn btn-outline-secondary org-edit">Edit</button>
-                          <button class="btn btn-outline-danger org-delete">Delete</button>
+                          <a class="btn btn-outline-primary" href="{{ url_for('main.start_auth', org_id=org.id) }}">{{ t('orgs.table.actions.connect') }}</a>
+                          <button class="btn btn-outline-secondary org-edit">{{ t('orgs.table.actions.edit') }}</button>
+                          <button class="btn btn-outline-danger org-delete">{{ t('orgs.table.actions.delete') }}</button>
                         </div>
                       </td>
                     </tr>
@@ -97,7 +97,7 @@
               </table>
             </div>
           {% else %}
-            <p class="text-muted">No orgs configured yet.</p>
+            <p class="text-muted">{{ t('orgs.table.empty') }}</p>
           {% endif %}
         </div>
       </div>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-6">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h5 class="card-title">{{ t('settings.title') }}</h5>
+        {% if language_saved %}
+          <div class="alert alert-success" role="status">
+            {{ t('settings.language_saved') }}
+          </div>
+        {% endif %}
+        <form method="post">
+          <div class="mb-3">
+            <label class="form-label" for="language">{{ t('settings.language_label') }}</label>
+            <select class="form-select" id="language" name="language">
+              {% for language in available_languages %}
+                <option value="{{ language.code }}" {% if language.code == current_language %}selected{% endif %}>
+                  {{ language.label }}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+          <button class="btn btn-primary" type="submit">{{ t('settings.language_submit') }}</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add translation dictionaries and helpers for English and Italian along with template context injection
- introduce a settings page that stores the preferred language in the session
- localize existing templates and client-side messaging to support the selected language

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dba9d46e148324977d7bcda803791a