### PR TITLE
Add configurable themes to settings

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -162,8 +162,15 @@ _LANGUAGE_PACKS: Dict[str, Dict[str, Any]] = {
         "settings": {
             "title": "Settings",
             "language_label": "Language",
-            "language_submit": "Save settings",
-            "language_saved": "Language updated successfully.",
+            "theme_label": "Theme",
+            "save_button": "Save settings",
+            "saved": "Settings updated successfully.",
+            "themes": {
+                "classic": "Classic",
+                "modern": "Modern",
+                "dark": "Dark",
+                "sci-fi": "Sci-fi",
+            },
         },
         "frontend": {
             "toast": {
@@ -349,8 +356,15 @@ _LANGUAGE_PACKS: Dict[str, Dict[str, Any]] = {
         "settings": {
             "title": "Impostazioni",
             "language_label": "Lingua",
-            "language_submit": "Salva impostazioni",
-            "language_saved": "Lingua aggiornata correttamente.",
+            "theme_label": "Tema",
+            "save_button": "Salva impostazioni",
+            "saved": "Impostazioni aggiornate correttamente.",
+            "themes": {
+                "classic": "Classico",
+                "modern": "Moderno",
+                "dark": "Scuro",
+                "sci-fi": "Fantascienza",
+            },
         },
         "frontend": {
             "toast": {

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,5 +1,128 @@
 body {
   min-height: 100vh;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+body.theme-classic {
+  background-color: #f8f9fa;
+  color: #212529;
+}
+
+body.theme-modern {
+  background: linear-gradient(180deg, #f0f4ff 0%, #eef2ff 100%);
+  color: #1f2933;
+}
+
+body.theme-dark {
+  background-color: #0b1120;
+  color: #e2e8f0;
+}
+
+body.theme-sci-fi {
+  background: radial-gradient(circle at 20% 20%, rgba(78, 205, 196, 0.25), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(69, 123, 157, 0.35), transparent 65%),
+    #050a1a;
+  color: #d8e2ff;
+}
+
+.theme-classic .navbar {
+  background-color: #0d6efd;
+}
+
+.theme-modern .navbar {
+  background: linear-gradient(90deg, #4f46e5, #22d3ee);
+}
+
+.theme-dark .navbar {
+  background-color: #111827;
+}
+
+.theme-sci-fi .navbar {
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #38bdf8 100%);
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.4);
+}
+
+.theme-dark .navbar .nav-link,
+.theme-sci-fi .navbar .nav-link,
+.theme-dark .navbar .navbar-brand,
+.theme-sci-fi .navbar .navbar-brand {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.theme-modern .navbar .navbar-brand,
+.theme-modern .navbar .nav-link {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.theme-modern .navbar .nav-link.active,
+.theme-modern .navbar .nav-link:hover,
+.theme-dark .navbar .nav-link.active,
+.theme-dark .navbar .nav-link:hover,
+.theme-sci-fi .navbar .nav-link.active,
+.theme-sci-fi .navbar .nav-link:hover {
+  color: #ffffff;
+}
+
+.theme-dark .card,
+.theme-sci-fi .card {
+  background-color: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: inherit;
+}
+
+.theme-modern .card {
+  border: none;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+}
+
+.theme-sci-fi .card {
+  box-shadow: 0 10px 40px rgba(56, 189, 248, 0.25);
+}
+
+.theme-dark .btn-primary,
+.theme-sci-fi .btn-primary {
+  background-color: #2563eb;
+  border-color: #2563eb;
+}
+
+.theme-modern .btn-primary {
+  background: linear-gradient(90deg, #6366f1, #22d3ee);
+  border: none;
+}
+
+.theme-modern .btn-primary:focus,
+.theme-modern .btn-primary:hover {
+  box-shadow: 0 0 0 0.25rem rgba(99, 102, 241, 0.3);
+}
+
+.theme-dark .form-control,
+.theme-dark .form-select,
+.theme-sci-fi .form-control,
+.theme-sci-fi .form-select {
+  background-color: rgba(15, 23, 42, 0.95);
+  color: inherit;
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.theme-dark .form-control:focus,
+.theme-dark .form-select:focus,
+.theme-sci-fi .form-control:focus,
+.theme-sci-fi .form-select:focus {
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 0.2rem rgba(56, 189, 248, 0.25);
+  color: #ffffff;
+}
+
+.theme-dark .form-control::placeholder,
+.theme-dark .form-select::placeholder,
+.theme-sci-fi .form-control::placeholder,
+.theme-sci-fi .form-select::placeholder {
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.theme-modern .form-control,
+.theme-modern .form-select {
+  border-color: rgba(99, 102, 241, 0.4);
 }
 
 .org-select.active {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
   </head>
-  <body class="bg-light">
+  <body class="theme-{{ current_theme }}">
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
       <div class="container">
         <a class="navbar-brand" href="{{ url_for('main.index') }}">{{ t('nav.brand') }}</a>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -5,9 +5,9 @@
     <div class="card shadow-sm">
       <div class="card-body">
         <h5 class="card-title">{{ t('settings.title') }}</h5>
-        {% if language_saved %}
+        {% if settings_saved %}
           <div class="alert alert-success" role="status">
-            {{ t('settings.language_saved') }}
+            {{ t('settings.saved') }}
           </div>
         {% endif %}
         <form method="post">
@@ -21,7 +21,17 @@
               {% endfor %}
             </select>
           </div>
-          <button class="btn btn-primary" type="submit">{{ t('settings.language_submit') }}</button>
+          <div class="mb-3">
+            <label class="form-label" for="theme">{{ t('settings.theme_label') }}</label>
+            <select class="form-select" id="theme" name="theme">
+              {% for theme in available_themes %}
+                <option value="{{ theme.id }}" {% if theme.id == current_theme %}selected{% endif %}>
+                  {{ theme.label }}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+          <button class="btn btn-primary" type="submit">{{ t('settings.save_button') }}</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a theme selector to the settings page with Classic, Modern, Dark, and Sci-fi options
- persist the chosen theme in the session and expose it to templates for styling
- implement themed styles and translations for both English and Italian locales

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dbb2d0a5308324a11a3e536113cc21