### PR TITLE
Expand query workspace and enhance autocomplete

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -163,7 +163,7 @@ body.theme-sci-fi {
 .saved-query-list,
 .metadata-list,
 .query-history-list {
-  max-height: 250px;
+  max-height: 220px;
   overflow-y: auto;
 }
 
@@ -201,4 +201,22 @@ body.theme-sci-fi {
     position: sticky;
     top: 1rem;
   }
+}
+
+.sidebar-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sidebar-tools-card .nav-tabs .nav-link {
+  white-space: nowrap;
+}
+
+.sidebar-tools-card .tab-content {
+  padding-top: 1rem;
+}
+
+.sidebar-tools-card .tab-pane > :last-child {
+  margin-bottom: 0;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,122 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="row g-4 align-items-start">
-  <div class="col-12 col-lg-4 col-xl-3 order-2 order-lg-1">
-    <div class="d-flex flex-column gap-4">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h5 class="card-title">{{ t('index.select_org.title') }}</h5>
-          <p class="card-text">{{ t('index.select_org.description') }}</p>
-          <div class="mb-3">
-            <label class="form-label" for="selected-org">{{ t('index.query.selected_org_label') }}</label>
-            <input
-              id="selected-org"
-              class="form-control"
-              type="text"
-              placeholder="{{ t('index.query.selected_org_placeholder') }}"
-              readonly
-            />
-          </div>
-          <div id="org-list">
-            {% if orgs %}
-              <div class="list-group">
-                {% for org in orgs %}
-                  <button type="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center org-select" data-org="{{ org.id }}">
-                    <span>
-                      <strong>{{ org.label }}</strong>
-                      <span class="d-block small text-muted">{{ org.environment }}</span>
-                    </span>
-                    {% if org.access_token %}
-                      <span class="badge bg-success">{{ t('index.select_org.connected_badge') }}</span>
-                    {% else %}
-                      <span class="badge bg-secondary">{{ t('index.select_org.not_connected_badge') }}</span>
-                    {% endif %}
-                  </button>
-                {% endfor %}
-              </div>
-            {% else %}
-              <p class="text-muted">{{ t('index.select_org.empty') }}</p>
-            {% endif %}
-          </div>
-          <a class="btn btn-outline-primary mt-3" href="{{ url_for('main.manage_orgs') }}">{{ t('index.select_org.manage_button') }}</a>
-        </div>
-      </div>
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h6 class="card-title">{{ t('index.query.saved_queries.title') }}</h6>
-          <form id="saved-query-form" class="row g-2 align-items-end">
-            <input type="hidden" id="saved-query-id" />
-            <div class="col-sm-7">
-              <label class="form-label" for="saved-query-name">{{ t('index.query.saved_queries.name_label') }}</label>
-              <input
-                id="saved-query-name"
-                class="form-control"
-                type="text"
-                placeholder="{{ t('index.query.saved_queries.name_placeholder') }}"
-              />
-            </div>
-            <div class="col-sm-auto">
-              <button
-                type="submit"
-                id="saved-query-submit"
-                class="btn btn-success"
-                data-label-save="{{ t('index.query.saved_queries.save_button') }}"
-                data-label-update="{{ t('index.query.saved_queries.update_button') }}"
-              >
-                {{ t('index.query.saved_queries.save_button') }}
-              </button>
-            </div>
-            <div class="col-sm-auto">
-              <button type="button" id="saved-query-reset" class="btn btn-outline-secondary">
-                {{ t('index.query.saved_queries.reset_button') }}
-              </button>
-            </div>
-          </form>
-          <div class="mt-3">
-            <div id="saved-queries-empty" class="text-muted small">
-              {{ t('index.query.saved_queries.empty') }}
-            </div>
-            <div
-              id="saved-queries-list"
-              class="list-group saved-query-list"
-              data-label-load="{{ t('index.query.saved_queries.load_button') }}"
-              data-label-delete="{{ t('index.query.saved_queries.delete_button') }}"
-            ></div>
-          </div>
-        </div>
-      </div>
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h6 class="card-title">{{ t('index.query.history.title') }}</h6>
-          <div class="mb-3">
-            <label class="form-label" for="query-history-filter">{{ t('index.query.history.filter_label') }}</label>
-            <select
-              id="query-history-filter"
-              class="form-select"
-              data-label-all="{{ t('index.query.history.filter_all') }}"
-            ></select>
-          </div>
-          <div id="query-history-empty" class="text-muted small">
-            {{ t('index.query.history.empty') }}
-          </div>
-          <div
-            id="query-history-list"
-            class="list-group query-history-list"
-            data-label-unknown="{{ t('index.query.history.object_unknown') }}"
-            data-label-org="{{ t('index.query.history.org_label') }}"
-          ></div>
-        </div>
-      </div>
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <h6 class="card-title">{{ t('index.help.title') }}</h6>
-          <p class="card-text">{{ t('index.help.description') }}</p>
-          <a class="btn btn-sm btn-primary" href="{{ url_for('main.guide') }}">{{ t('index.help.guide_button') }}</a>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="col-12 col-lg-8 col-xl-6 order-1 order-lg-2">
+  <div class="col-12 col-xl-8 col-xxl-9">
     <div class="card shadow-sm h-100">
       <div class="card-body d-flex flex-column">
         <h5 class="card-title">{{ t('index.query.title') }}</h5>
@@ -151,35 +36,202 @@
       </div>
     </div>
   </div>
-  <div class="col-12 col-xl-3 order-3">
-    <div class="card shadow-sm sticky-sidebar">
-      <div class="card-body">
-        <h6 class="card-title">{{ t('index.query.autocomplete.title') }}</h6>
-        <div class="mb-3">
-          <label class="form-label" for="object-search">{{ t('index.query.autocomplete.objects_label') }}</label>
-          <input
-            id="object-search"
-            class="form-control"
-            type="search"
-            placeholder="{{ t('index.query.autocomplete.objects_placeholder') }}"
-          />
-          <div id="objects-loading" class="text-muted small d-none">
-            {{ t('index.query.autocomplete.loading') }}
+  <div class="col-12 col-xl-4 col-xxl-3">
+    <div class="sticky-sidebar">
+      <div class="sidebar-stack">
+        <div class="card shadow-sm">
+          <div class="card-body">
+            <h6 class="card-title">{{ t('index.query.autocomplete.title') }}</h6>
+            <div class="mb-3">
+              <label class="form-label" for="object-search">{{ t('index.query.autocomplete.objects_label') }}</label>
+              <input
+                id="object-search"
+                class="form-control"
+                type="search"
+                placeholder="{{ t('index.query.autocomplete.objects_placeholder') }}"
+              />
+              <div id="objects-loading" class="text-muted small d-none">
+                {{ t('index.query.autocomplete.loading') }}
+              </div>
+              <div id="objects-empty" class="text-muted small">
+                {{ t('index.query.autocomplete.objects_empty') }}
+              </div>
+              <div id="object-list" class="list-group metadata-list"></div>
+            </div>
+            <div>
+              <label class="form-label">{{ t('index.query.autocomplete.fields_label') }}</label>
+              <div id="fields-loading" class="text-muted small d-none">
+                {{ t('index.query.autocomplete.loading') }}
+              </div>
+              <div id="fields-empty" class="text-muted small">
+                {{ t('index.query.autocomplete.fields_empty') }}
+              </div>
+              <div id="field-list" class="list-group metadata-list"></div>
+            </div>
           </div>
-          <div id="objects-empty" class="text-muted small">
-            {{ t('index.query.autocomplete.objects_empty') }}
-          </div>
-          <div id="object-list" class="list-group metadata-list"></div>
         </div>
-        <div>
-          <label class="form-label">{{ t('index.query.autocomplete.fields_label') }}</label>
-          <div id="fields-loading" class="text-muted small d-none">
-            {{ t('index.query.autocomplete.loading') }}
+        <div class="card shadow-sm sidebar-tools-card">
+          <div class="card-header border-bottom-0 pb-0">
+            <ul class="nav nav-tabs card-header-tabs nav-fill small" id="sidebar-sections" role="tablist">
+              <li class="nav-item" role="presentation">
+                <button
+                  class="nav-link active"
+                  id="sidebar-orgs-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#sidebar-orgs"
+                  type="button"
+                  role="tab"
+                  aria-controls="sidebar-orgs"
+                  aria-selected="true"
+                >
+                  {{ t('index.select_org.title') }}
+                </button>
+              </li>
+              <li class="nav-item" role="presentation">
+                <button
+                  class="nav-link"
+                  id="sidebar-saved-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#sidebar-saved"
+                  type="button"
+                  role="tab"
+                  aria-controls="sidebar-saved"
+                  aria-selected="false"
+                >
+                  {{ t('index.query.saved_queries.title') }}
+                </button>
+              </li>
+              <li class="nav-item" role="presentation">
+                <button
+                  class="nav-link"
+                  id="sidebar-history-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#sidebar-history"
+                  type="button"
+                  role="tab"
+                  aria-controls="sidebar-history"
+                  aria-selected="false"
+                >
+                  {{ t('index.query.history.title') }}
+                </button>
+              </li>
+              <li class="nav-item" role="presentation">
+                <button
+                  class="nav-link"
+                  id="sidebar-help-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#sidebar-help"
+                  type="button"
+                  role="tab"
+                  aria-controls="sidebar-help"
+                  aria-selected="false"
+                >
+                  {{ t('index.help.title') }}
+                </button>
+              </li>
+            </ul>
           </div>
-          <div id="fields-empty" class="text-muted small">
-            {{ t('index.query.autocomplete.fields_empty') }}
+          <div class="card-body">
+            <div class="tab-content" id="sidebar-sections-content">
+              <div class="tab-pane fade show active" id="sidebar-orgs" role="tabpanel" aria-labelledby="sidebar-orgs-tab">
+                <p class="text-muted small">{{ t('index.select_org.description') }}</p>
+                <div class="mb-3">
+                  <label class="form-label" for="selected-org">{{ t('index.query.selected_org_label') }}</label>
+                  <input
+                    id="selected-org"
+                    class="form-control"
+                    type="text"
+                    placeholder="{{ t('index.query.selected_org_placeholder') }}"
+                    readonly
+                  />
+                </div>
+                <div id="org-list">
+                  {% if orgs %}
+                    <div class="list-group">
+                      {% for org in orgs %}
+                        <button type="button" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center org-select" data-org="{{ org.id }}">
+                          <span>
+                            <strong>{{ org.label }}</strong>
+                            <span class="d-block small text-muted">{{ org.environment }}</span>
+                          </span>
+                          {% if org.access_token %}
+                            <span class="badge bg-success">{{ t('index.select_org.connected_badge') }}</span>
+                          {% else %}
+                            <span class="badge bg-secondary">{{ t('index.select_org.not_connected_badge') }}</span>
+                          {% endif %}
+                        </button>
+                      {% endfor %}
+                    </div>
+                  {% else %}
+                    <p class="text-muted small">{{ t('index.select_org.empty') }}</p>
+                  {% endif %}
+                </div>
+                <a class="btn btn-sm btn-outline-primary mt-3" href="{{ url_for('main.manage_orgs') }}">{{ t('index.select_org.manage_button') }}</a>
+              </div>
+              <div class="tab-pane fade" id="sidebar-saved" role="tabpanel" aria-labelledby="sidebar-saved-tab">
+                <form id="saved-query-form" class="row g-2 align-items-end">
+                  <input type="hidden" id="saved-query-id" />
+                  <div class="col-12">
+                    <label class="form-label" for="saved-query-name">{{ t('index.query.saved_queries.name_label') }}</label>
+                    <input
+                      id="saved-query-name"
+                      class="form-control"
+                      type="text"
+                      placeholder="{{ t('index.query.saved_queries.name_placeholder') }}"
+                    />
+                  </div>
+                  <div class="col d-flex gap-2">
+                    <button
+                      type="submit"
+                      id="saved-query-submit"
+                      class="btn btn-success flex-fill"
+                      data-label-save="{{ t('index.query.saved_queries.save_button') }}"
+                      data-label-update="{{ t('index.query.saved_queries.update_button') }}"
+                    >
+                      {{ t('index.query.saved_queries.save_button') }}
+                    </button>
+                    <button type="button" id="saved-query-reset" class="btn btn-outline-secondary flex-fill">
+                      {{ t('index.query.saved_queries.reset_button') }}
+                    </button>
+                  </div>
+                </form>
+                <div class="mt-3">
+                  <div id="saved-queries-empty" class="text-muted small">
+                    {{ t('index.query.saved_queries.empty') }}
+                  </div>
+                  <div
+                    id="saved-queries-list"
+                    class="list-group saved-query-list"
+                    data-label-load="{{ t('index.query.saved_queries.load_button') }}"
+                    data-label-delete="{{ t('index.query.saved_queries.delete_button') }}"
+                  ></div>
+                </div>
+              </div>
+              <div class="tab-pane fade" id="sidebar-history" role="tabpanel" aria-labelledby="sidebar-history-tab">
+                <div class="mb-3">
+                  <label class="form-label" for="query-history-filter">{{ t('index.query.history.filter_label') }}</label>
+                  <select
+                    id="query-history-filter"
+                    class="form-select"
+                    data-label-all="{{ t('index.query.history.filter_all') }}"
+                  ></select>
+                </div>
+                <div id="query-history-empty" class="text-muted small">
+                  {{ t('index.query.history.empty') }}
+                </div>
+                <div
+                  id="query-history-list"
+                  class="list-group query-history-list"
+                  data-label-unknown="{{ t('index.query.history.object_unknown') }}"
+                  data-label-org="{{ t('index.query.history.org_label') }}"
+                ></div>
+              </div>
+              <div class="tab-pane fade" id="sidebar-help" role="tabpanel" aria-labelledby="sidebar-help-tab">
+                <p class="card-text small">{{ t('index.help.description') }}</p>
+                <a class="btn btn-sm btn-primary" href="{{ url_for('main.guide') }}">{{ t('index.help.guide_button') }}</a>
+              </div>
+            </div>
           </div>
-          <div id="field-list" class="list-group metadata-list"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- broaden the main query editor column and condense supporting tools into a tabbed sidebar to free more space for query authoring
- tweak sidebar styling for the new stacked layout and reduced list heights
- extend field suggestions to detect SELECT and WHERE cursor positions, include whitespace/comma triggers, and insert fields contextually

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dbe35dd54c8324b1333a80b57fbb2e