### PR TITLE
Add confirmation for unconstrained queries and widen desktop layout

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -227,7 +227,10 @@ _LANGUAGE_PACKS: Dict[str, Dict[str, Any]] = {
                 },
             },
             "form": {"update_button": "Update org", "save_button": "Save org"},
-            "confirm": {"delete_org": "Delete org {orgId}?"},
+            "confirm": {
+                "delete_org": "Delete org {orgId}?",
+                "query_without_limit_where": "Are you sure you want to run a query without LIMIT nor WHERE?",
+            },
             "saved_queries": {"load": "Load", "delete": "Delete"},
             "autocomplete": {"insert": "Insert"},
             "history": {
@@ -456,7 +459,10 @@ _LANGUAGE_PACKS: Dict[str, Dict[str, Any]] = {
                 },
             },
             "form": {"update_button": "Aggiorna organizzazione", "save_button": "Salva organizzazione"},
-            "confirm": {"delete_org": "Eliminare l'organizzazione {orgId}?"},
+            "confirm": {
+                "delete_org": "Eliminare l'organizzazione {orgId}?",
+                "query_without_limit_where": "Sei sicuro di voler eseguire una query senza LIMIT né WHERE?",
+            },
             "saved_queries": {"load": "Carica", "delete": "Elimina"},
             "autocomplete": {"insert": "Inserisci"},
             "history": {

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -989,6 +989,19 @@ function bindQueryForm() {
       showToast(translate("toast.enter_query"), "warning");
       return;
     }
+
+    const hasLimit = /\bLIMIT\b/i.test(query);
+    const hasWhere = /\bWHERE\b/i.test(query);
+    if (!hasLimit && !hasWhere) {
+      const message = translate("frontend.confirm.query_without_limit_where");
+      if (typeof window.confirm === "function") {
+        const shouldProceed = window.confirm(message);
+        if (!shouldProceed) {
+          return;
+        }
+      }
+    }
+
     try {
       const response = await fetch("/api/query", {
         method: "POST",

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,7 +9,7 @@
   </head>
   <body class="theme-{{ current_theme }}">
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-      <div class="container">
+      <div class="container-xxl">
         <a class="navbar-brand" href="{{ url_for('main.index') }}">{{ t('nav.brand') }}</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -33,7 +33,7 @@
       </div>
     </nav>
 
-    <main class="container mb-5">
+    <main class="container-xxl mb-5">
       {% block content %}{% endblock %}
     </main>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="row g-4 align-items-start">
-  <div class="col-12 col-xl-8 col-xxl-9">
+  <div class="col-12 col-xl-9 col-xxl-10">
     <div class="card shadow-sm h-100">
       <div class="card-body d-flex flex-column">
         <h5 class="card-title">{{ t('index.query.title') }}</h5>
@@ -36,7 +36,7 @@
       </div>
     </div>
   </div>
-  <div class="col-12 col-xl-4 col-xxl-3">
+  <div class="col-12 col-xl-3 col-xxl-2">
     <div class="sticky-sidebar">
       <div class="sidebar-stack">
         <div class="card shadow-sm">


### PR DESCRIPTION
## Summary
- prompt the user before running queries that lack both LIMIT and WHERE clauses
- localize the new confirmation message in English and Italian
- widen the desktop layout by using the xl/xxl containers and adjusting column balance

## Testing
- python -m flask --app app run --host=0.0.0.0 --port=5000

------
https://chatgpt.com/codex/tasks/task_e_68dbe8bd4d648324bfef91626f5ea9dc