### PR TITLE
Persist user settings and saved queries in LocalStorage

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -10,7 +10,7 @@
             {{ t('settings.saved') }}
           </div>
         {% endif %}
-        <form method="post">
+        <form method="post" id="app-settings-form">
           <div class="mb-3">
             <label class="form-label" for="language">{{ t('settings.language_label') }}</label>
             <select class="form-select" id="language" name="language">


### PR DESCRIPTION
## Summary
- add helper utilities to safely read and write application state to LocalStorage
- hydrate saved queries, the query editor, and org selection from stored data and keep them in sync
- persist theme and language preferences via the settings form using LocalStorage

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dbea94ae648324941278c493e00ff3