### PR TITLE
Adjust query sidebar layout and validation

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -216,6 +216,7 @@ _LANGUAGE_PACKS: Dict[str, Dict[str, Any]] = {
                 "results_export_ready_csv": "CSV download started",
                 "results_export_ready_excel": "Excel download started",
                 "results_export_failed": "Unable to export results",
+                "query_without_limit_where": "Add a WHERE or LIMIT clause before running the query.",
             },
             "query": {
                 "no_records": "No records returned.",
@@ -448,6 +449,7 @@ _LANGUAGE_PACKS: Dict[str, Dict[str, Any]] = {
                 "results_export_ready_csv": "Download CSV avviato",
                 "results_export_ready_excel": "Download Excel avviato",
                 "results_export_failed": "Impossibile esportare i risultati",
+                "query_without_limit_where": "Aggiungi una clausola WHERE o LIMIT prima di eseguire la query.",
             },
             "query": {
                 "no_records": "Nessun record restituito.",

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1275,13 +1275,8 @@ function bindQueryForm() {
     const hasLimit = /\bLIMIT\b/i.test(query);
     const hasWhere = /\bWHERE\b/i.test(query);
     if (!hasLimit && !hasWhere) {
-      const message = translate("frontend.confirm.query_without_limit_where");
-      if (typeof window.confirm === "function") {
-        const shouldProceed = window.confirm(message);
-        if (!shouldProceed) {
-          return;
-        }
-      }
+      showToast(translate("frontend.toast.query_without_limit_where"), "danger");
+      return;
     }
 
     saveQueryDraftToStorage(queryInput?.value ?? query);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -196,6 +196,38 @@ body.theme-sci-fi {
   border-color: rgba(59, 130, 246, 0.35);
 }
 
+.query-layout {
+  position: relative;
+}
+
+.query-sidebar {
+  z-index: 2;
+}
+
+@media (min-width: 1400px) {
+  .query-layout {
+    --query-sidebar-width: clamp(300px, 26vw, 380px);
+    --query-sidebar-gap: 1.5rem;
+  }
+
+  .query-layout .query-main {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+
+  .query-layout .query-sidebar {
+    position: absolute;
+    top: 0;
+    right: calc(var(--query-sidebar-gap) - ((100vw - 100%) / 2));
+    width: var(--query-sidebar-width);
+  }
+
+  .query-layout .query-sidebar .sticky-sidebar {
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+  }
+}
+
 @media (min-width: 1200px) {
   .sticky-sidebar {
     position: sticky;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="row g-4 align-items-start">
-  <div class="col-12 col-xl-9 col-xxl-10">
+<div class="row g-4 align-items-start query-layout">
+  <div class="col-12 col-xl-9 query-main">
     <div class="card shadow-sm h-100">
       <div class="card-body d-flex flex-column">
         <h5 class="card-title">{{ t('index.query.title') }}</h5>
@@ -36,7 +36,7 @@
       </div>
     </div>
   </div>
-  <div class="col-12 col-xl-3 col-xxl-2">
+  <div class="col-12 col-xl-3 query-sidebar">
     <div class="sticky-sidebar">
       <div class="sidebar-stack">
         <div class="card shadow-sm">


### PR DESCRIPTION
## Summary
- reposition the SOQL helper sidebar so it uses the outer margin on wide screens without shrinking the main query card
- surface a red toast when a query is submitted without a WHERE or LIMIT clause instead of using a confirm dialog
- localize the new toast message in English and Italian

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf5b9b2c4832480e07826c70593fb