### PR TITLE
Improve account explorer resiliency and messaging

### DIFF
--- a/app/static/settings.js
+++ b/app/static/settings.js
@@ -1,7 +1,17 @@
 (function () {
   function translateKey(key, params = {}) {
     if (typeof translate === "function") {
-      return translate(key, params);
+      const normalizedKey =
+        typeof key === "string" && key.startsWith("frontend.")
+          ? key.slice("frontend.".length)
+          : key;
+      const translated = translate(normalizedKey, params);
+      if (translated !== normalizedKey) {
+        return translated;
+      }
+      if (normalizedKey !== key) {
+        return key;
+      }
     }
     return key;
   }
@@ -63,12 +73,16 @@
             return;
           }
           const current = orgSelect.value;
+          const existingPlaceholder = orgSelect.querySelector(
+            'option[value=""]'
+          );
+          const placeholderText = existingPlaceholder?.textContent?.trim()
+            ? existingPlaceholder.textContent.trim()
+            : translateKey("settings.account_explorer.org_placeholder");
           orgSelect.innerHTML = "";
           const placeholder = document.createElement("option");
           placeholder.value = "";
-          placeholder.textContent = translateKey(
-            "settings.account_explorer.org_placeholder"
-          );
+          placeholder.textContent = placeholderText;
           orgSelect.appendChild(placeholder);
           data.forEach((org) => {
             const option = document.createElement("option");


### PR DESCRIPTION
## Summary
- add Salesforce error parsing so optional account explorer objects are skipped gracefully while surfacing warnings to the UI
- expose collected warnings and enhanced status messaging in the account explorer, including better error handling of server responses
- fix translation helper usage for account explorer screens to respect existing placeholders and frontend keys

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e51ca4a2e08324a1f08190c3c433f4