### PR TITLE
Fix custom object lookups in Account Explorer

### DIFF
--- a/app/data_import.py
+++ b/app/data_import.py
@@ -15,16 +15,16 @@ DATA_IMPORT_SESSION_KEY = "data_import_session_id"
 
 DATA_IMPORT_OBJECTS: List[Dict[str, str]] = [
     {"key": "Account", "label": "Account"},
-    {"key": "BillingProfile", "label": "Billing Profile"},
+    {"key": "BillingProfile__c", "label": "Billing Profile"},
     {"key": "Contact", "label": "Contact"},
     {"key": "Contract", "label": "Contract"},
-    {"key": "AccountContactRelationship", "label": "Account Contact Relationship"},
+    {"key": "AccountContactRelation", "label": "Account Contact Relation"},
     {"key": "Individual", "label": "Individual"},
     {"key": "ContactPointPhone", "label": "Contact Point Phone"},
     {"key": "ContactPointEmail", "label": "Contact Point Email"},
     {"key": "Case", "label": "Case"},
     {"key": "Order", "label": "Order"},
-    {"key": "Sale", "label": "Sale"},
+    {"key": "Sale__c", "label": "Sale"},
 ]
 
 _OBJECT_LOOKUP = {item["key"]: item for item in DATA_IMPORT_OBJECTS}


### PR DESCRIPTION
## Summary
- update the account explorer configuration to use the correct custom object API names and safer default fields
- ensure contact point records are fetched via both individual and contact lookups when building account details
- align the data import object metadata with the updated API names

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e526afe7d48324be41c50956999470